### PR TITLE
Lit 2 Upgrade - Phase 2: Breaking changes

### DIFF
--- a/carousel.js
+++ b/carousel.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
 class Carousel extends LocalizeDynamicMixin(LitElement) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^2",
+    "@brightspace-ui/core": "^1",
     "lit-element": "^3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui/core": "^2",
+    "lit-element": "^3"
   }
 }


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 

- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] backwards-compatible changes merged: https://github.com/BrightspaceUILabs/carousel/pull/9

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [] Testing component in the LMS --NOT CURRENTLY BEING USED ANYWHERE--

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.